### PR TITLE
variant_label returned the enum name instead of variant name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ macro_rules! __c_enum_no_debug {
                     Self::Inner: PartialEq
                 {
                     Some(match &self.0 {
-                        $( value if Self::$field.0 == *value => ::core::stringify!($name), )*
+                        $( value if Self::$field.0 == *value => ::core::stringify!($field), )*
                         _ => return None,
                     })
                 }


### PR DESCRIPTION
I love your crate, it does exactly what I needed, but I believe this is a bug. 
variant_label now returns the name of the variant instead of the name of the enum