### PR TITLE
Make variants without explicit values properly follow C enum rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,15 +294,11 @@ macro_rules! __c_enum_no_debug {
             #[allow(non_upper_case_globals)]
             impl $name {
                 $crate::__c_enum_impl!(
-                    impl(decl_variants, $name, $inner)
-                    [ $(
+                    impl(decl_variants, $name, $inner, 0)
+                    $(
                         $( #[$field_attr] )*
                         $field $( = $value )?,
-                    )*]
-                    [
-                        __dummy = 0,
-                        $( $field $( = $value )?, )*
-                    ]
+                    )*
                 );
             }
 
@@ -347,32 +343,25 @@ macro_rules! __c_enum_impl {
         $first
     };
 
+    (impl(decl_variants, $name:ident, $inner:ty, $default:expr)) => {};
     (
-        impl(decl_variants, $name:ident, $inner:ty)
-        [ ]
-        [ $( $__:ident $( = $prev:expr )? ),* $(,)? ]
-    ) => {};
-    (
-        impl(decl_variants, $name:ident, $inner:ty)
-        [
-            $( #[$fattr:meta] )*
-            $field:ident $( = $fvalue:expr )?
-            $( ,
-                $( #[$rattr:meta] )*
-                $frest:ident $( = $frest_val:expr )?
-            )*
-            $(,)?
-        ]
-        [ $prev:ident  $( = $pvalue:expr )? $( , $prest:ident $( = $prest_val:expr )? )* $(,)? ]
+        impl(decl_variants, $name:ident, $inner:ty, $default:expr)
+        $( #[$fattr:meta] )*
+        $field:ident $( = $fvalue:expr )?
+        $( ,
+            $( #[$rattr:meta] )*
+            $frest:ident $( = $frest_val:expr )?
+        )*
+        $(,)?
     ) => {
         $( #[$fattr] )*
         #[allow(non_upper_case_globals)]
-        pub const $field: Self = Self($crate::__c_enum_impl!(impl(first_expr) $( $fvalue, )? $( $pvalue, )? 0));
+        pub const $field: Self = Self($crate::__c_enum_impl!(
+            impl(first_expr) $( $fvalue, )? $default));
 
         $crate::__c_enum_impl!(
-            impl(decl_variants, $name, $inner)
-            [ $( $( #[$rattr] )* $frest $( = $frest_val )?, )* ]
-            [ $( $prest $( = $prest_val )?, )* ]
+            impl(decl_variants, $name, $inner, Self::$field.0 + 1)
+            $( $( #[$rattr] )* $frest $( = $frest_val )?, )*
         );
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,19 +2,6 @@ use c_enum::*;
 
 c_enum! {
     #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-    pub enum Hardware : u64 {
-        /// Doc comments
-        CPU_CYCLES,
-        INSTRUCTIONS = 2,
-        CACHE_REFERENCES,
-        CACHE_MISSES,
-        BRANCH_INSTRUCTIONS = 5,
-        Lowercase,
-    }
-}
-
-c_enum! {
-    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     pub enum Software : u64 {
         /// Doc comments
         CPU_CYCLES,
@@ -35,6 +22,12 @@ c_enum! {
 }
 
 #[test]
+fn increment_after_assign() {
+    assert_eq!(Software::Lowercase.0, 6);
+    assert_ne!(Software::Lowercase, Software::BRANCH_INSTRUCTIONS);
+}
+
+#[test]
 fn duplicates_are_equal() {
     assert_eq!(Duplicates::ITEM1, Duplicates::ITEM2);
 }
@@ -50,4 +43,22 @@ fn variant_label_duplicate() {
     // the one whose label is used.
     assert_eq!(Duplicates::ITEM1.variant_label(), Some("ITEM1"));
     assert_eq!(Duplicates::ITEM2.variant_label(), Some("ITEM1"));
+}
+
+#[test]
+fn variant_label_overlap_assigned() {
+    c_enum! {
+        #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+        enum Overlap : u32 {
+            A1 = 2,
+            A2,
+            A3,
+            B1 = 2,
+            B2,
+            B3
+        }
+    }
+
+    assert_eq!(Overlap::A1, Overlap::B1);
+    assert_eq!(Overlap::A3, Overlap::B3);
 }


### PR DESCRIPTION
In C, enum variants without an explicit value take the value $prev + 1, or 0, if they are the first variant. The constants generated by this crate are meant to follow the same convention.

Before this commit, due to a bug in the macro, they don't follow that convention. What happens instead is that all variants without assigned values have the value 0, unless they directly follow a variant with an assigned value, in which case they take the same value as the previous variant. This is _wrong_. The fix here is to explicitly pass a default value through and set that to either 0 (for the first field) or Self::$prev + 1 (for all other fields).

I have also included test cases that verify that the values of enum variants are as expected.