### PR TITLE
Only allow a single struct definition per c_enum! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- It is now only possible to define a single enum instance within a `c_enum!`.
+  This is to allow additional syntax in the future that is not supported when
+  the macro allows multiple enum definitions.
 
 ## 0.1.2 - 2023-09-25
 ### Fixed


### PR DESCRIPTION
This change is needed to allow additional syntax to be added in the future. There are limitation around what you can add without running into parsing ambiguities so the change needed to be made.

This is a breaking change but migrating to the new version is just a matter of breaking up larger `c_enum!` blocks.