### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 0.2.0 - 2023-10-23
 ### Added
 - `c_enum!` now has some extra syntax to allow directly applying attributes to
   the generated impl block.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-enum"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.56"
 description = "A macro to generate c-like enums."


### PR DESCRIPTION
## 0.2.0 - 2023-10-23
### Added
- `c_enum!` now has some extra syntax to allow directly applying attributes to the generated impl block.

### Changed
- It is now only possible to define a single enum instance within a `c_enum!`. This is to allow additional syntax in the future that is not supported when the macro allows multiple enum definitions.