### PR TITLE
Improve error messages for multiple enums in a c_enum! block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- `c_enum!` will now emit a custom error message indicating that declaring
+  multiple enums in a single `c_enum!` block is not supported anymore.
 
 ## 0.2.0 - 2023-10-23
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,9 @@ macro_rules! c_enum {
             $( #[$iattr:meta] )*
             impl {}
         )?
+
+        // Capture part of a potential next entry in order to emit a better error.
+        $( $evis:vis enum $($error:tt)+ )?
     } => {
         $crate::__c_enum_no_debug! {
             $( #[$attr] )*
@@ -293,6 +296,16 @@ macro_rules! c_enum {
                 }
             }
         }
+
+        $(
+            $crate::__expects_no_input! {
+                $evis enum $($error)+
+            }
+
+            compile_error!(
+                "Declaring multiple enums using a single c_enum! macro block is no longer supported",
+            );
+        )?
     };
 }
 
@@ -400,6 +413,15 @@ macro_rules! __c_enum_impl {
             $( $( #[$rattr] )* $frest $( = $frest_val )?, )*
         );
     }
+}
+
+/// Helper macro to emit a "no rules expected the token `...`" error message.
+///
+/// We use this mainly to emit proper error messages when the user provides
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __expects_no_input {
+    {} => {};
 }
 
 // This needs to be after all the macro definitions.


### PR DESCRIPTION
Version 0.2.0 removed the ability to declare multiple enums in a single c_enum! block. However, if you have existing code that does this then the error message doesn't really explain what went wrong. This commit adds a custom compile_error! message in addition to the regular error.